### PR TITLE
 no product preview + provider list for each ditribution in  lang/master/tpl/home.mtt

### DIFF
--- a/lang/master/tpl/home.mtt
+++ b/lang/master/tpl/home.mtt
@@ -154,7 +154,7 @@
 						<div class="content orders">
 							<table class="table table-bordered">
 							<tr>
-									<th colspan="3">Producteurs présents à cette ditribution</th>
+									<th colspan="3"> Producteurs participants</th>
 								</tr>
 
 								::set vdistribs = d.getDistributions(1)::

--- a/lang/master/tpl/home.mtt
+++ b/lang/master/tpl/home.mtt
@@ -147,22 +147,50 @@
 							
 						</div>
 
-					::elseif(hasShopMode)::
-						<div class="content orders">
-							<!-- products previews-->
-							::foreach p d.getProductsExcerpt(8)::
-							<div data-toggle="tooltip" data-placement="top" title="::p.name::"  style="background-image:url('::p.image::')" class="productImg medium"/> 
-							::end::
-						</div>
-					::end::
 					
 					::if(hasShopMode)::
 						
 						<!-- no var order : if shopmode, display order btn -->
 						<div class="content orders">
+							<table class="table table-bordered">
+							<tr>
+									<th colspan="3">Producteurs présents à cette ditribution</th>
+								</tr>
+
+								::set vdistribs = d.getDistributions(1)::
+								::set cdistribs = d.getDistributions(0)::
+
+								::foreach d vdistribs::
+
+									::if(d.length>0)::
+										<td>
+											::set contract = d._catalog::
+											<a href="/contract/view/::contract.id::">::contract.name::</a>
+										</td>
+										<td>
+											::contract._vendor.name::
+										</td>
+									::end::
+								::end::
+
+								::foreach d cdistribs::
+
+									::if(d.length>0)::
+										<td>
+											::set contract = d._catalog::
+											<a href="/contract/view/::contract.id::">::contract.name::</a>
+										</td>
+										<td>
+											::contract._vendor.name::
+										</td>
+									::end::
+								::end::
+							</table>
+
 							::set status = d.getState()::
 							<div class="text-center">
-								::if(status=="notYetOpen")::
+
+								if(status=="notYetOpen")::
 
 								<span class="disabled" style="font-size: 1.2em;">
 									<i class="icon icon-clock"></i>


### PR DESCRIPTION
Hello!
J'aimerai bien participer au développement de l'app cagette.net mais je n'arrive pas a builder sous windows (impossible d'augmenter le nombre de fichiers ouverts en même temps) ni avec travis ( `ligne  353: $ yes | haxelib install cagette.hxml / Failed with error: No such Project : cagette.hxml` )
Du coup je ne peux pas vérifier le rendu des modifications du code..

1. D'après les premiers retours utilisateurs la `product preview` n'est pas assez claire, surtout lorsque les produits n'ont pas de photo, j'ai supprimé cette section.
2. Lorsqu'il y a plusieurs commandes en cours, on peut les différencier grâce aux dates mais on peut rajouter l'information des producteurs présents pour chaque distribution. J'ai rajouté cette section en m'inspirant de lang/master/tpl/distribution/default.mtt
